### PR TITLE
Fix bigint parse and display error in staking and unstaking forms

### DIFF
--- a/src/components/staking/simulation.tsx
+++ b/src/components/staking/simulation.tsx
@@ -24,7 +24,7 @@ export default function StakingSimulation({
   const amountBigInt = strToBigInt(amount, staking.depositCurrency?.decimals);
 
   const reward = useMemo(() => {
-    if (!staking.depositCurrency) return BigInt(0);
+    if (!staking.depositCurrency || !amountBigInt) return BigInt(0);
     return (
       (amountBigInt * BigInt(staking.dailyRewardPerTokenStaked)) /
       BigInt(10) ** BigInt(staking.depositCurrency.decimals)

--- a/src/components/staking/staking-form.tsx
+++ b/src/components/staking/staking-form.tsx
@@ -59,7 +59,7 @@ export default function StakingForm({
   const amountBigInt = strToBigInt(amount, staking.depositCurrency?.decimals);
 
   const requireAllowance = useMemo(() => {
-    if (!allowance?.result) return true;
+    if (allowance?.result === undefined) return true;
     return allowance.result < amountBigInt;
   }, [allowance, amountBigInt]);
 

--- a/src/components/staking/staking-form.tsx
+++ b/src/components/staking/staking-form.tsx
@@ -163,10 +163,7 @@ export default function StakingForm({
                   )
                 : undefined
             }
-            step={
-              1 / 10 ** Math.min(13, staking.depositCurrency?.decimals || 18)
-              // 13 decimals is the maximum step
-            }
+            step={0.0001}
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             className="pr-16 invalid:text-red-600"

--- a/src/components/staking/unstaking-form.tsx
+++ b/src/components/staking/unstaking-form.tsx
@@ -34,7 +34,7 @@ export default function UnstakingForm({
   const amountBigInt = strToBigInt(amount, staking.depositCurrency?.decimals);
 
   const hasError = useMemo(() => {
-    if (amountBigInt === BigInt(0)) return true;
+    if (!amountBigInt) return true;
     if (
       position.data?.tokensStaked !== undefined &&
       amountBigInt > BigInt(position.data.tokensStaked)
@@ -44,9 +44,9 @@ export default function UnstakingForm({
   }, [amountBigInt, position.data]);
 
   const errorMessage = useMemo(() => {
-    // only display not valid amount error if amount was set by user as the default is 0
-    if (amount !== "" && amountBigInt === BigInt(0))
-      return "Enter valid amount";
+    // only display error if amount was set by user
+    if (amount === "") return;
+    if (!amountBigInt) return "Enter valid amount";
     if (
       position.data?.tokensStaked !== undefined &&
       amountBigInt > BigInt(position.data.tokensStaked)
@@ -61,6 +61,7 @@ export default function UnstakingForm({
   const unstake = useMutation({
     mutationFn: async () => {
       if (!client) throw new Error("Client not found");
+      if (!amountBigInt) throw new Error("no valid amount");
       await chain.switchChainAsync({ chainId: staking.chainId });
       const hash = await unstakeTx.writeContractAsync({
         chainId: staking.chainId,
@@ -117,7 +118,7 @@ export default function UnstakingForm({
                   )
                 : undefined
             }
-            step={0.0001}
+            step={0.001}
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             className="pr-16 invalid:text-red-600"

--- a/src/components/staking/unstaking-form.tsx
+++ b/src/components/staking/unstaking-form.tsx
@@ -117,10 +117,7 @@ export default function UnstakingForm({
                   )
                 : undefined
             }
-            step={
-              1 / 10 ** Math.min(13, staking.depositCurrency?.decimals || 18)
-              // 13 decimals is the maximum step
-            }
+            step={0.0001}
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             className="pr-16 invalid:text-red-600"

--- a/src/lib/bigint.ts
+++ b/src/lib/bigint.ts
@@ -1,4 +1,10 @@
+import { InvalidDecimalNumberError, parseUnits } from "viem";
+
 export function strToBigInt(value: string, decimals: number = 18): bigint {
-  if (!value) return BigInt(0);
-  return BigInt(Math.floor(parseFloat(value) * 10 ** decimals));
+  try {
+    return parseUnits(value, decimals);
+  } catch (error) {
+    if (error instanceof InvalidDecimalNumberError) return BigInt(0);
+    throw error;
+  }
 }

--- a/src/lib/bigint.ts
+++ b/src/lib/bigint.ts
@@ -1,10 +1,13 @@
 import { InvalidDecimalNumberError, parseUnits } from "viem";
 
-export function strToBigInt(value: string, decimals: number = 18): bigint {
+export function strToBigInt(
+  value: string,
+  decimals: number = 18
+): bigint | undefined {
   try {
     return parseUnits(value, decimals);
   } catch (error) {
-    if (error instanceof InvalidDecimalNumberError) return BigInt(0);
+    if (error instanceof InvalidDecimalNumberError) return undefined;
     throw error;
   }
 }


### PR DESCRIPTION
- update `strToBigInt` to use `parseUnits` and catch invalid number error. The app was crashing on any not valid number.
- fix allowance check when allowance is zero
- add error management to staking and unstaking form